### PR TITLE
fix code analysis and support flutter_quill 9.1.0

### DIFF
--- a/lib/src/custom_quill_attributes.dart
+++ b/lib/src/custom_quill_attributes.dart
@@ -6,6 +6,6 @@ class CodeBlockLanguageAttribute extends Attribute<String?> {
   static const attrKey = 'x-md-codeblock-lang';
 
   /// @nodoc
-  CodeBlockLanguageAttribute(String? value)
-      : super(attrKey, AttributeScope.IGNORE, value);
+  const CodeBlockLanguageAttribute(String? value)
+      : super(attrKey, AttributeScope.ignore, value);
 }

--- a/lib/src/delta_to_markdown.dart
+++ b/lib/src/delta_to_markdown.dart
@@ -5,6 +5,7 @@ import 'dart:ui';
 
 import 'package:collection/collection.dart';
 import 'package:flutter_quill/flutter_quill.dart';
+import 'package:flutter_quill/quill_delta.dart';
 import 'package:markdown_quill/src/custom_quill_attributes.dart';
 import 'package:markdown_quill/src/utils.dart';
 
@@ -212,7 +213,7 @@ class DeltaToMarkdown extends Converter<Delta, String>
       }
     });
     if (style.isEmpty ||
-        style.values.every((item) => item.scope != AttributeScope.BLOCK)) {
+        style.values.every((item) => item.scope != AttributeScope.block)) {
       out.writeln();
     }
     if (style.containsKey(Attribute.list.key) &&

--- a/lib/src/delta_to_markdown.dart
+++ b/lib/src/delta_to_markdown.dart
@@ -224,7 +224,7 @@ class DeltaToMarkdown extends Converter<Delta, String>
   }
 
   @override
-  StringSink visitText(Text text, [StringSink? output]) {
+  StringSink visitText(QuillText text, [StringSink? output]) {
     final out = output ??= StringBuffer();
     final style = text.style;
     _handleAttribute(
@@ -303,7 +303,7 @@ abstract class _NodeVisitor<T> {
 
   T visitLine(Line line, [T? context]);
 
-  T visitText(Text text, [T? context]);
+  T visitText(QuillText text, [T? context]);
 
   T visitEmbed(Embed embed, [T? context]);
 }
@@ -317,8 +317,8 @@ extension _NodeX on Node {
         return visitor.visitBlock(this as Block, context);
       case Line:
         return visitor.visitLine(this as Line, context);
-      case Text:
-        return visitor.visitText(this as Text, context);
+      case QuillText:
+        return visitor.visitText(this as QuillText, context);
       case Embed:
         return visitor.visitEmbed(this as Embed, context);
     }

--- a/lib/src/markdown_to_delta.dart
+++ b/lib/src/markdown_to_delta.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:collection/collection.dart';
 import 'package:flutter_quill/flutter_quill.dart';
+import 'package:flutter_quill/quill_delta.dart';
 import 'package:markdown/markdown.dart' as md;
 import 'package:markdown_quill/src/custom_quill_attributes.dart';
 import 'package:markdown_quill/src/embeddable_table_syntax.dart';

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,5 +1,6 @@
 //ignore_for_file: cast_nullable_to_non_nullable
 import 'package:flutter_quill/flutter_quill.dart';
+import 'package:flutter_quill/quill_delta.dart';
 import 'package:markdown_quill/src/embeddable_table_syntax.dart';
 
 /// To allow embedding images/videos in horizontal mode.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   charcode: ^1.3.1
   collection: ^1.17.1
-  flutter_quill: ^7.2.6
+  flutter_quill: ^9.1.0
   markdown: ^7.1.0
 
 dev_dependencies:


### PR DESCRIPTION
Currently, the code doesn't pass static analysis. It looks to me like `Text` has been renamed to `QuillText` in the flutter_quill package in https://github.com/singerdmx/flutter-quill/commit/7c5a12b14009dcd30c4d8e05d7cfcbd76f92fa4b in the `leaf.dart` file.

Here are the `flutter analyze` errors:
```log
  error • Undefined class 'Text' • lib/src/delta_to_markdown.dart:227:24 • undefined_class
  error • Undefined class 'Text' • lib/src/delta_to_markdown.dart:306:15 • undefined_class
  error • Case expressions must be constant • lib/src/delta_to_markdown.dart:320:12 • non_constant_case_expression
  error • Undefined name 'Text' • lib/src/delta_to_markdown.dart:320:12 • undefined_identifier
  error • The name 'Text' isn't a type, so it can't be used in an 'as' expression • lib/src/delta_to_markdown.dart:321:42 • cast_to_non_type
```

Changing `Text` to `QuillText` fixes all the errors above.