### PR TITLE
Option to keep empty lines

### DIFF
--- a/lib/src/delta_to_markdown.dart
+++ b/lib/src/delta_to_markdown.dart
@@ -38,6 +38,10 @@ extension on Object? {
   }
 }
 
+///
+typedef DeltaToMarkdownVisitLineHandleNewLine = void Function(
+    Style style, StringSink out);
+
 /// Convertor from [Delta] to quill Markdown string.
 class DeltaToMarkdown extends Converter<Delta, String>
     implements _NodeVisitor<StringSink> {
@@ -45,6 +49,7 @@ class DeltaToMarkdown extends Converter<Delta, String>
   DeltaToMarkdown({
     Map<String, EmbedToMarkdown>? customEmbedHandlers,
     Map<String, CustomAttributeHandler>? customTextAttrsHandlers,
+    this.visitLineHandleNewLine,
   }) {
     if (customEmbedHandlers != null) {
       _embedHandlers.addAll(customEmbedHandlers);
@@ -59,6 +64,9 @@ class DeltaToMarkdown extends Converter<Delta, String>
       }
     }
   }
+
+  /// allows custom handling of adding new lines to quill Markdown string
+  final DeltaToMarkdownVisitLineHandleNewLine? visitLineHandleNewLine;
 
   @override
   String convert(Delta input) {
@@ -235,6 +243,10 @@ class DeltaToMarkdown extends Converter<Delta, String>
         leaf.accept(this, out);
       }
     });
+    if (visitLineHandleNewLine != null) {
+      visitLineHandleNewLine?.call(style, out);
+      return out;
+    }
     if (style.isEmpty ||
         style.values.every((item) => item.scope != AttributeScope.block)) {
       out.writeln();

--- a/test/keep_empty_lines_test.dart
+++ b/test/keep_empty_lines_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_quill/flutter_quill.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:markdown/markdown.dart' as md;
+import 'package:markdown_quill/markdown_quill.dart';
+
+final _mdDocument = md.Document(
+  encodeHtml: false,
+  blockSyntaxes: [const KeepEmptyLineBlockSyntax()],
+  extensionSet: md.ExtensionSet.gitHubFlavored,
+);
+
+final _mdToDelta = MarkdownToDelta(
+  markdownDocument: _mdDocument,
+);
+
+final _deltaToMd = DeltaToMarkdown(
+  visitLineHandleNewLine: (style, out) => out.writeln(),
+);
+
+void main() {
+  test('!', () {
+    _verify('\\!\n');
+  });
+
+  test('1NL', () {
+    _verify('''
+First line
+
+Third line
+''');
+  });
+
+  test('1NL+ENL', () {
+    _verify('''
+First line
+
+Third line
+
+''');
+  });
+
+  test('2NL', () {
+    _verify('''
+First line
+
+
+Third line
+''');
+  });
+
+  test('2NL+ENL', () {
+    _verify('''
+First line
+
+
+Third line
+
+''');
+  });
+}
+
+void _verify(String input) {
+  final delta = _mdToDelta.convert(input);
+  final document = Document.fromDelta(delta);
+  final reMarkdown = _deltaToMd.convert(document.toDelta());
+
+  expect(reMarkdown, input);
+}
+
+class KeepEmptyLineBlockSyntax extends md.BlockSyntax {
+  @override
+  RegExp get pattern => RegExp(r'^(?:[ \t]*)$');
+
+  const KeepEmptyLineBlockSyntax();
+
+  @override
+  md.Node? parse(md.BlockParser parser) {
+    parser.advance();
+
+    return md.Element.text('p', '');
+  }
+}


### PR DESCRIPTION
## What is this PR about?

This allows for markdown newlines to stay "intact" if they go through `MD` -> `DELTA` -> `MD` conversion loop.

## Description of changes

Added extra non breaking API to `DeltaToMarkdown` and a few unit tests to verify this change under `test/keep_empty_lines_test.dart`