### PR TITLE
add ability to customize special character escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.0
+
+* Add `DeltaToMarkdown.customContentHandler` that allows you to configure how special characters are escaped
+
 ## 4.0.0
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: markdown_quill
 description: Convert between quill (delta) format and markdown
-version: 4.0.0
+version: 4.1.0
 repository: https://github.com/TarekkMA/markdown_quill
 
 environment:

--- a/test/relaxed_escaping_test.dart
+++ b/test/relaxed_escaping_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_quill/flutter_quill.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:markdown/markdown.dart' as md;
+import 'package:markdown_quill/markdown_quill.dart';
+
+void main() {
+  test('default escaping', () {
+    _checkEscaping(
+      input: '''
+Not all characters **should** be escaped.
+
+1. This neither.
+
+''',
+      output: r'''
+Not all characters **should** be escaped\.
+
+1. This neither\.
+
+''',
+      relaxed: false,
+    );
+  });
+
+  test('relaxed escaping', () {
+    const input = '''
+Not all characters **should** be escaped.
+
+1. This neither.
+
+''';
+    _checkEscaping(
+      input: input,
+      output: input, // no escape characters should be added
+      relaxed: true,
+    );
+  });
+}
+
+void _checkEscaping({
+  required String input,
+  required String output,
+  required bool relaxed,
+}) {
+  final mdDocument = md.Document(
+    encodeHtml: false,
+    extensionSet: md.ExtensionSet.gitHubFlavored,
+  );
+
+  final mdToDelta = MarkdownToDelta(
+    markdownDocument: mdDocument,
+  );
+
+  final deltaToMd = relaxed
+      ? DeltaToMarkdown(
+          customContentHandler: DeltaToMarkdown.escapeSpecialCharactersRelaxed)
+      : DeltaToMarkdown();
+
+  final delta = mdToDelta.convert(input);
+  final document = Document.fromDelta(delta);
+  final reMarkdown = deltaToMd.convert(document.toDelta());
+
+  expect(reMarkdown, output);
+}


### PR DESCRIPTION
## What is this PR about?

Currently all special characters (that are part of markdown syntax) are getting escaped, e.g. `.` becomes `\.` when converting from quill to markdown. This is a reasonable but not always a desirable approach.

This PR adds customization of this behavior.

## Description of changes

- Move the escaping logic from `visitText` to a separate static method called `escapeSpecialCharacters`
- Create signature for the method called `CustomContentHandler` and make it available as a constructor parameter of `DeltaToMarkdown`
- Make the constructor use `escapeSpecialCharacters` by default
- Add secondary static method called `escapeSpecialCharactersRelaxed` that conforms to the signature of `CustomContentHandler` and also escapes special characters, but only when text is styled, meaning fullstops should be omitted.
- Add unit test to illustrate the issue and validate the implementation.

