### PR TITLE
[Draft] issue #22 repro & workaround

### DIFF
--- a/test/issue_22_test.dart
+++ b/test/issue_22_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_quill/flutter_quill.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:markdown/markdown.dart' as md;
+import 'package:markdown_quill/markdown_quill.dart';
+
+import 'utils/custom_blockquote_syntax.dart';
+import 'utils/keep_empty_line_block_syntax.dart';
+
+/// https://github.com/TarekkMA/markdown_quill/issues/22
+void main() {
+  /// in this approach we prevent second line being merged into quote block
+  /// by supplying [CustomBlockquoteSyntax]
+  test(
+    'quotes disappearing/merging',
+    () {
+      // given
+      const inputMarkdown = '''
+> This is a quote
+This is another line
+
+''';
+
+      final mdDocument = md.Document(
+        encodeHtml: false,
+        blockSyntaxes: [
+          const KeepEmptyLineBlockSyntax(),
+          const CustomBlockquoteSyntax(acceptParagraphContinuation: false)
+        ],
+        extensionSet: md.ExtensionSet.gitHubFlavored,
+      );
+
+      final mdToDelta = MarkdownToDelta(
+        markdownDocument: mdDocument,
+      );
+
+      final deltaToMd = DeltaToMarkdown(
+        visitLineHandleNewLine: (style, out) => out.writeln(),
+      );
+
+      // when
+      final delta = mdToDelta.convert(inputMarkdown);
+
+      final document = Document.fromDelta(delta);
+      final reMarkdown = deltaToMd.convert(document.toDelta());
+
+      // then
+      expect(reMarkdown, inputMarkdown);
+    },
+  );
+}

--- a/test/keep_empty_lines_test.dart
+++ b/test/keep_empty_lines_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:markdown/markdown.dart' as md;
 import 'package:markdown_quill/markdown_quill.dart';
 
+import 'utils/keep_empty_line_block_syntax.dart';
+
 final _mdDocument = md.Document(
   encodeHtml: false,
   blockSyntaxes: [const KeepEmptyLineBlockSyntax()],
@@ -65,18 +67,4 @@ void _verify(String input) {
   final reMarkdown = _deltaToMd.convert(document.toDelta());
 
   expect(reMarkdown, input);
-}
-
-class KeepEmptyLineBlockSyntax extends md.BlockSyntax {
-  @override
-  RegExp get pattern => RegExp(r'^(?:[ \t]*)$');
-
-  const KeepEmptyLineBlockSyntax();
-
-  @override
-  md.Node? parse(md.BlockParser parser) {
-    parser.advance();
-
-    return md.Element.text('p', '');
-  }
 }

--- a/test/ol_ul_bug_test.dart
+++ b/test/ol_ul_bug_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_quill/flutter_quill.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:markdown/markdown.dart' as md;
+import 'package:markdown_quill/markdown_quill.dart';
+
+import 'utils/custom_list_syntax.dart';
+import 'utils/keep_empty_line_block_syntax.dart';
+
+void main() {
+  test(
+    'ordered/unordered list merging',
+    () {
+      // given
+      const inputMarkdown = '''
+1. This is ordered list
+This is a simple line
+- This is unordered list
+''';
+
+      final mdDocument = md.Document(
+        encodeHtml: false,
+        blockSyntaxes: const [
+          CustomOrderedListSyntax(acceptParagraphContinuation: false),
+          CustomUnorderedListSyntax(acceptParagraphContinuation: false),
+          KeepEmptyLineBlockSyntax(),
+        ],
+        extensionSet: md.ExtensionSet.gitHubFlavored,
+      );
+
+      final mdToDelta = MarkdownToDelta(
+        markdownDocument: mdDocument,
+      );
+
+      final deltaToMd = DeltaToMarkdown(
+          visitLineHandleNewLine: (style, out) => out.writeln());
+
+      // when
+      final delta = mdToDelta.convert(inputMarkdown);
+
+      final document = Document.fromDelta(delta);
+      final reMarkdown = deltaToMd.convert(document.toDelta());
+
+      // then
+      expect(reMarkdown, inputMarkdown);
+    },
+  );
+}

--- a/test/utils/custom_blockquote_syntax.dart
+++ b/test/utils/custom_blockquote_syntax.dart
@@ -1,0 +1,101 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:markdown/markdown.dart';
+import 'package:markdown/src/charcode.dart';
+import 'package:markdown/src/patterns.dart';
+import 'package:markdown/src/util.dart';
+
+/// this is a copy-paste from blockquote_syntax (added acceptParagraphContinuation flag)
+/// Parses email-style blockquotes: `> quote`.
+class CustomBlockquoteSyntax extends BlockSyntax {
+  @override
+  RegExp get pattern => blockquotePattern;
+
+  const CustomBlockquoteSyntax({
+    required this.acceptParagraphContinuation,
+  });
+
+  // if true, paragraph procedeing blockquote gets merged into the quote (unless it's empty)
+  final bool acceptParagraphContinuation;
+
+  /// Whether this blockquote ends with a lazy continuation line.
+  // The definition of lazy continuation lines:
+  // https://spec.commonmark.org/0.30/#lazy-continuation-line
+  static var _lazyContinuation = false;
+  @override
+  List<Line> parseChildLines(BlockParser parser) {
+    // Grab all of the lines that form the blockquote, stripping off the ">".
+    final childLines = <Line>[];
+    _lazyContinuation = false;
+
+    while (!parser.isDone) {
+      final currentLine = parser.current;
+      final match = pattern.firstMatch(parser.current.content);
+      if (match != null) {
+        // A block quote marker consists of a `>` together with an optional
+        // following space of indentation, see
+        // https://spec.commonmark.org/0.30/#block-quote-marker.
+        final markerStart = match.match.indexOf('>');
+        int markerEnd;
+        if (currentLine.content.length > 1) {
+          var hasSpace = false;
+          // Check if there is a following space if the marker is not at the end
+          // of this line.
+          if (markerStart < currentLine.content.length - 1) {
+            final nextChar = currentLine.content.codeUnitAt(markerStart + 1);
+            hasSpace = nextChar == $tab || nextChar == $space;
+          }
+          markerEnd = markerStart + (hasSpace ? 2 : 1);
+        } else {
+          markerEnd = markerStart + 1;
+        }
+        childLines.add(Line(currentLine.content.substring(markerEnd)));
+        parser.advance();
+        _lazyContinuation = false;
+        continue;
+      }
+
+      final lastLine = childLines.last;
+
+      // A paragraph continuation is OK. This is content that cannot be parsed
+      // as any other syntax except Paragraph, and it doesn't match the bar in
+      // a Setext header.
+      // Because indented code blocks cannot interrupt paragraphs, a line
+      // matched CodeBlockSyntax is also paragraph continuation text.
+      final otherMatched =
+          parser.blockSyntaxes.firstWhere((s) => s.canParse(parser));
+      if ((acceptParagraphContinuation &&
+              otherMatched is ParagraphSyntax &&
+              !lastLine.isBlankLine &&
+              !codeFencePattern.hasMatch(lastLine.content)) ||
+          (otherMatched is CodeBlockSyntax &&
+              !indentPattern.hasMatch(lastLine.content))) {
+        childLines.add(parser.current);
+        _lazyContinuation = true;
+        parser.advance();
+      } else {
+        break;
+      }
+    }
+
+    return childLines;
+  }
+
+  @override
+  Node parse(BlockParser parser) {
+    final childLines = parseChildLines(parser);
+
+    // Recursively parse the contents of the blockquote.
+    final children = BlockParser(childLines, parser.document).parseLines(
+      // The setext heading underline cannot be a lazy continuation line in a
+      // block quote.
+      // https://spec.commonmark.org/0.30/#example-93
+      disabledSetextHeading: _lazyContinuation,
+      parentSyntax: this,
+    );
+
+    return Element('blockquote', children);
+  }
+}

--- a/test/utils/custom_list_syntax.dart
+++ b/test/utils/custom_list_syntax.dart
@@ -1,0 +1,375 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:markdown/markdown.dart';
+import 'package:markdown/src/charcode.dart';
+import 'package:markdown/src/patterns.dart';
+import 'package:markdown/src/text_parser.dart';
+import 'package:markdown/src/util.dart';
+
+class ListItem {
+  const ListItem(
+    this.lines, {
+    this.taskListItemState,
+  });
+
+  final List<Line> lines;
+  final TaskListItemState? taskListItemState;
+}
+
+enum TaskListItemState { checked, unchecked }
+
+/// Base class for both ordered and unordered lists.
+abstract class CustomListSyntax extends BlockSyntax {
+  // if true, paragraph procedeing blockquote gets merged into the quote (unless it's empty)
+  final bool acceptParagraphContinuation;
+
+  @override
+  bool canParse(BlockParser parser) =>
+      pattern.hasMatch(parser.current.content) &&
+      !hrPattern.hasMatch(parser.current.content);
+
+  @override
+  bool canEndBlock(BlockParser parser) {
+    // An empty list cannot interrupt a paragraph. See
+    // https://spec.commonmark.org/0.30/#example-285.
+    // Ideally, [BlockSyntax.canEndBlock] should be changed to be a method
+    // which accepts a [BlockParser], but this would be a breaking change,
+    // so we're going with this temporarily.
+    final match = pattern.firstMatch(parser.current.content)!;
+
+    // Allow only lists starting with 1 to interrupt paragraphs, if it is an
+    // ordered list. See https://spec.commonmark.org/0.30/#example-304.
+    // But there should be an exception for nested ordered lists, for example:
+    // ```
+    // 1. one
+    // 2. two
+    //   3. three
+    //   4. four
+    // 5. five
+    // ```
+    if (parser.parentSyntax is! CustomListSyntax &&
+        match[1] != null &&
+        match[1] != '1') {
+      return false;
+    }
+
+    // An empty list item cannot interrupt a paragraph. See
+    // https://spec.commonmark.org/0.30/#example-285
+    return match[2]?.isNotEmpty ?? false;
+  }
+
+  const CustomListSyntax({required this.acceptParagraphContinuation});
+
+  /// A list of patterns that can start a valid block within a list item.
+  static final blocksInList = [
+    blockquotePattern,
+    headerPattern,
+    hrPattern,
+    indentPattern,
+    listPattern,
+  ];
+
+  @override
+  Node parse(BlockParser parser) {
+    final match = pattern.firstMatch(parser.current.content);
+    final ordered = match![1] != null;
+
+    final taskListParserEnabled = this is UnorderedListWithCheckboxSyntax ||
+        this is OrderedListWithCheckboxSyntax;
+    final items = <ListItem>[];
+    var childLines = <Line>[];
+    TaskListItemState? taskListItemState;
+
+    void endItem() {
+      if (childLines.isNotEmpty) {
+        items.add(ListItem(childLines, taskListItemState: taskListItemState));
+        childLines = <Line>[];
+      }
+    }
+
+    String parseTaskListItem(String text) {
+      final pattern = RegExp(r'^ {0,3}\[([ xX])\][ \t]');
+
+      if (taskListParserEnabled && pattern.hasMatch(text)) {
+        return text.replaceFirstMapped(pattern, (match) {
+          taskListItemState = match[1] == ' '
+              ? TaskListItemState.unchecked
+              : TaskListItemState.checked;
+
+          return '';
+        });
+      } else {
+        taskListItemState = null;
+        return text;
+      }
+    }
+
+    late Match? possibleMatch;
+    bool tryMatch(RegExp pattern) {
+      possibleMatch = pattern.firstMatch(parser.current.content);
+      return possibleMatch != null;
+    }
+
+    String? listMarker;
+    int? indent;
+    // In case the first number in an ordered list is not 1, use it as the
+    // "start".
+    int? startNumber;
+
+    int? blankLines;
+
+    while (!parser.isDone) {
+      final currentIndent = parser.current.content.indentation() +
+          (parser.current.tabRemaining ?? 0);
+
+      if (parser.current.isBlankLine) {
+        childLines.add(parser.current);
+
+        if (blankLines != null) {
+          blankLines++;
+        }
+      } else if (indent != null && indent <= currentIndent) {
+        // A list item can begin with at most one blank line. See:
+        // https://spec.commonmark.org/0.30/#example-280
+        if (blankLines != null && blankLines > 1) {
+          break;
+        }
+
+        final indentedLine = parser.current.content.dedent(indent);
+
+        childLines.add(Line(
+          blankLines == null
+              ? indentedLine.text
+              : parseTaskListItem(indentedLine.text),
+          tabRemaining: indentedLine.tabRemaining,
+        ));
+      } else if (tryMatch(hrPattern)) {
+        // Horizontal rule takes precedence to a new list item.
+        break;
+      } else if (tryMatch(listPattern)) {
+        blankLines = null;
+        final match = possibleMatch!;
+        final textParser = TextParser(parser.current.content);
+        var precedingWhitespaces = textParser.moveThroughWhitespace();
+        final markerStart = textParser.pos;
+        final digits = match[1] ?? '';
+        if (digits.isNotEmpty) {
+          startNumber ??= int.parse(digits);
+          textParser.advanceBy(digits.length);
+        }
+        textParser.advance();
+
+        // See https://spec.commonmark.org/0.30/#ordered-list-marker
+        final marker = textParser.substring(
+          markerStart,
+          textParser.pos,
+        );
+
+        var isBlank = true;
+        var contentWhitespances = 0;
+        var containsTab = false;
+        int? contentBlockStart;
+
+        if (!textParser.isDone) {
+          containsTab = textParser.charAt() == $tab;
+          // Skip the first whitespace.
+          textParser.advance();
+          contentBlockStart = textParser.pos;
+          if (!textParser.isDone) {
+            contentWhitespances = textParser.moveThroughWhitespace();
+
+            if (!textParser.isDone) {
+              isBlank = false;
+            }
+          }
+        }
+
+        // Changing the bullet or ordered list delimiter starts a new list.
+        if (listMarker != null && listMarker.last() != marker.last()) {
+          break;
+        }
+
+        // End the current list item and start a new one.
+        endItem();
+
+        // Start a new list item, the last item will be ended up outside of the
+        // `while` loop.
+        listMarker = marker;
+        precedingWhitespaces += digits.length + 2;
+        if (isBlank) {
+          // See https://spec.commonmark.org/0.30/#example-278.
+          blankLines = 1;
+          indent = precedingWhitespaces;
+        } else if (contentWhitespances >= 4) {
+          // See https://spec.commonmark.org/0.30/#example-270.
+          //
+          // If the list item starts with indented code, we need to _not_ count
+          // any indentation past the required whitespace character.
+          indent = precedingWhitespaces;
+        } else {
+          indent = precedingWhitespaces + contentWhitespances;
+        }
+
+        taskListItemState = null;
+        var content = contentBlockStart != null && !isBlank
+            ? parseTaskListItem(textParser.substring(contentBlockStart))
+            : '';
+
+        if (content.isEmpty && containsTab) {
+          content = content.prependSpace(2);
+        }
+
+        childLines.add(Line(
+          content,
+          tabRemaining: containsTab ? 2 : null,
+        ));
+      } else if (BlockSyntax.isAtBlockEnd(parser)) {
+        // Done with the list.
+        break;
+      } else {
+        // If the previous item is a blank line, this means we're done with the
+        // list and are starting a new top-level paragraph.
+        if (childLines.isNotEmpty && childLines.last.isBlankLine) {
+          parser.encounteredBlankLine = true;
+          break;
+        }
+
+        // Anything else is paragraph continuation text.
+        if (acceptParagraphContinuation) {
+          childLines.add(parser.current);
+        } else {
+          break;
+        }
+      }
+      parser.advance();
+    }
+
+    endItem();
+    final itemNodes = <Element>[];
+
+    items.forEach(_removeLeadingEmptyLine);
+    final anyEmptyLines = _removeTrailingEmptyLines(items);
+    var anyEmptyLinesBetweenBlocks = false;
+    var containsTaskList = false;
+    const taskListClass = 'task-list-item';
+
+    for (final item in items) {
+      Element? checkboxToInsert;
+      if (item.taskListItemState != null) {
+        containsTaskList = true;
+        checkboxToInsert = Element.withTag('input')
+          ..attributes['type'] = 'checkbox';
+        if (item.taskListItemState == TaskListItemState.checked) {
+          checkboxToInsert.attributes['checked'] = 'true';
+        }
+      }
+
+      final itemParser = BlockParser(item.lines, parser.document);
+      final children = itemParser.parseLines(parentSyntax: this);
+      final itemElement = checkboxToInsert == null
+          ? Element('li', children)
+          : (Element('li', [checkboxToInsert, ...children])
+            ..attributes['class'] = taskListClass);
+
+      itemNodes.add(itemElement);
+      anyEmptyLinesBetweenBlocks =
+          anyEmptyLinesBetweenBlocks || itemParser.encounteredBlankLine;
+    }
+
+    // Must strip paragraph tags if the list is "tight".
+    // https://spec.commonmark.org/0.30/#lists
+    final listIsTight = !anyEmptyLines && !anyEmptyLinesBetweenBlocks;
+
+    if (listIsTight) {
+      // We must post-process the list items, converting any top-level paragraph
+      // elements to just text elements.
+      for (final item in itemNodes) {
+        final isTaskList = item.attributes['class'] == taskListClass;
+        final children = item.children;
+        if (children != null) {
+          Node? lastNode;
+          for (var i = 0; i < children.length; i++) {
+            final child = children[i];
+            if (child is Element && child.tag == 'p') {
+              final childContent = child.children!;
+              if (lastNode is Element && !isTaskList) {
+                childContent.insert(0, Text('\n'));
+              }
+
+              children
+                ..removeAt(i)
+                ..insertAll(i, childContent);
+            }
+
+            lastNode = child;
+          }
+        }
+      }
+    }
+
+    final listElement = Element(ordered ? 'ol' : 'ul', itemNodes);
+    if (ordered && startNumber != 1) {
+      listElement.attributes['start'] = '$startNumber';
+    }
+
+    if (containsTaskList) {
+      listElement.attributes['class'] = 'contains-task-list';
+    }
+    return listElement;
+  }
+
+  void _removeLeadingEmptyLine(ListItem item) {
+    if (item.lines.isNotEmpty && item.lines.first.isBlankLine) {
+      item.lines.removeAt(0);
+    }
+  }
+
+  /// Removes any trailing empty lines and notes whether any items are separated
+  /// by such lines.
+  bool _removeTrailingEmptyLines(List<ListItem> items) {
+    var anyEmpty = false;
+    for (var i = 0; i < items.length; i++) {
+      if (items[i].lines.length == 1) continue;
+      while (items[i].lines.isNotEmpty && items[i].lines.last.isBlankLine) {
+        if (i < items.length - 1) {
+          anyEmpty = true;
+        }
+        items[i].lines.removeLast();
+      }
+    }
+    return anyEmpty;
+  }
+}
+
+/// Parses ordered lists.
+class CustomOrderedListSyntax extends CustomListSyntax {
+  @override
+  RegExp get pattern => listPattern;
+
+  const CustomOrderedListSyntax({required super.acceptParagraphContinuation});
+}
+
+/// Parses unordered lists.
+class CustomUnorderedListSyntax extends CustomListSyntax {
+  @override
+  RegExp get pattern => listPattern;
+
+  @override
+  bool canParse(BlockParser parser) {
+    // Check if it matches `hrPattern`, otherwise it will produce an infinite
+    // loop if put `UnorderedListSyntax` or `UnorderedListWithCheckboxSyntax`
+    // bofore `HorizontalRuleSyntax` and parse:
+    // ```
+    // * * *
+    // ```
+    if (hrPattern.hasMatch(parser.current.content)) {
+      return false;
+    }
+
+    return pattern.hasMatch(parser.current.content);
+  }
+
+  const CustomUnorderedListSyntax({required super.acceptParagraphContinuation});
+}

--- a/test/utils/keep_empty_line_block_syntax.dart
+++ b/test/utils/keep_empty_line_block_syntax.dart
@@ -1,0 +1,15 @@
+import 'package:markdown/markdown.dart' as md;
+
+class KeepEmptyLineBlockSyntax extends md.BlockSyntax {
+  @override
+  RegExp get pattern => RegExp(r'^(?:[ \t]*)$');
+
+  const KeepEmptyLineBlockSyntax();
+
+  @override
+  md.Node? parse(md.BlockParser parser) {
+    parser.advance();
+
+    return md.Element.text('p', '');
+  }
+}


### PR DESCRIPTION
## What is this PR about?

When you have the following input markdown:

```md
> This is a quote
This is another line

```

The second line gets appended to the first line (expected markdown behavior). You can override this behavior by using `CustomBlockquoteSyntax` which doesn't allow paragraph continuation.

## Description of changes

- Added unit test to repro + workaround classes in `utils` folder.
- Added similar unit test/solution for ordered/unordered list