### PR TITLE
fix softline break getting removed before a newline link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.0
+
+* Fix `softLineBreak` not respected when a new line is starting with a link [#34](https://github.com/TarekkMA/markdown_quill/issues/34)
+
 ## 4.1.0
 
 * Add `DeltaToMarkdown.customContentHandler` that allows you to configure how special characters are escaped

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: markdown_quill
 description: Convert between quill (delta) format and markdown
-version: 4.1.0
+version: 4.2.0
 repository: https://github.com/TarekkMA/markdown_quill
 
 environment:

--- a/test/issue_34_test.dart
+++ b/test/issue_34_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_quill/quill_delta.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:markdown/markdown.dart' as md;
+import 'package:markdown_quill/markdown_quill.dart';
+
+void main() {
+  test('softLineBreak + link', () {
+    // given
+    const input = '''
+A text
+[a link](https://flutter.dev)
+''';
+
+    // when
+    final delta = MarkdownToDelta(
+      markdownDocument: md.Document(
+        encodeHtml: false,
+      ),
+      softLineBreak: true,
+    ).convert(input);
+
+    // then
+    expect(delta.operations, [
+      Operation.insert('A text\n'),
+      Operation.insert('a link', {'link': 'https://flutter.dev'}),
+      Operation.insert('\n'),
+    ]);
+  });
+
+  test('softLineBreak + link (an extra line at the end)', () {
+    // given
+    const input = '''
+A text
+[a link](https://flutter.dev)
+test!
+''';
+
+    // when
+    final delta = MarkdownToDelta(
+      markdownDocument: md.Document(
+        encodeHtml: false,
+      ),
+      softLineBreak: true,
+    ).convert(input);
+
+    // then
+    expect(delta.operations, [
+      Operation.insert('A text\n'),
+      Operation.insert('a link', {'link': 'https://flutter.dev'}),
+      Operation.insert('\ntest!\n'),
+    ]);
+  });
+}


### PR DESCRIPTION
## What is this PR about?

closes #34

Following markdown

```
A text
[a link](https://flutter.dev)
```

Would be turned into a single line (in delta):

```
A text a link
```

When `softLineBreak` is set to `true`. 

## Description of changes


- Modified `visitElementBefore` `visitText` to accommodate for this case in `softLineBreak` mode
- Added some tests.
