### PR TITLE
Add newline before each p element apart from the first

### DIFF
--- a/lib/src/markdown_to_delta.dart
+++ b/lib/src/markdown_to_delta.dart
@@ -264,6 +264,12 @@ class MarkdownToDelta extends Converter<String, Delta>
   }
 
   void _insertNewLineBeforeElementIfNeeded(md.Element element) {
+    // make sure this is not the first element
+    // in all other cases add a new line before p
+    if (_lastTag != null && element.tag == 'p') {
+      _delta.insert('\n');
+    }
+
     if (!_isInBlockQuote &&
         _lastTag == 'blockquote' &&
         element.tag == 'blockquote') {


### PR DESCRIPTION
Fixes https://github.com/TarekkMA/markdown_quill/issues/36 and probably https://github.com/TarekkMA/markdown_quill/issues/20 as well, however does break tests as of now.

Motivation behind this commit: Each p element in html starts by convention in a new line. As this has not been done so far some new lines have been swallowed, see example in https://github.com/TarekkMA/markdown_quill/issues/36

Tests will have to be adapted for this PR, however as I am not the owner, I would leave this to the maintainer to at least specify if that is fine. 
`00:19 +97 ~6 -28: Some tests failed.`

Thanks for you time and effort!